### PR TITLE
Update plugin.py

### DIFF
--- a/mkdocs_toc_sidebar_plugin/plugin.py
+++ b/mkdocs_toc_sidebar_plugin/plugin.py
@@ -14,7 +14,7 @@ import codecs
 class TocSidebar(BasePlugin):
 
     config_scheme = (
-        ('param', config_options.Type(mkdocs_utils.string_types, default='')),
+        ('param', config_options.Type(str, default='')),
     )
 
     def __init__(self):


### PR DESCRIPTION
Fix for _AttributeError: module 'mkdocs.utils' has no attribute 'string_types'_ after dropping support for Python 2.7 in Mkdocs

Can be tested by installing with `pip3 install git+https://github.com/Mandy91/mkdocs-toc-sidebar-plugin.git@drop_python_2.7_support`
