### PR TITLE
Beautification fix + support for Material v7.1.3

### DIFF
--- a/mkdocs_toc_sidebar_plugin/plugin.py
+++ b/mkdocs_toc_sidebar_plugin/plugin.py
@@ -34,6 +34,6 @@ class TocSidebar(BasePlugin):
             else:
                 print("WARNING: Table of Contents sidebar not found")
    
-        souped_html = soup.prettify(soup.original_encoding)
+        #souped_html = soup.prettify(soup.original_encoding)
         return souped_html 
 

--- a/mkdocs_toc_sidebar_plugin/plugin.py
+++ b/mkdocs_toc_sidebar_plugin/plugin.py
@@ -35,5 +35,6 @@ class TocSidebar(BasePlugin):
                 print("WARNING: Table of Contents sidebar not found")
    
         #souped_html = soup.prettify(soup.original_encoding)
+        souped_html = soup.encode(soup.original_encoding)
         return souped_html 
 

--- a/mkdocs_toc_sidebar_plugin/plugin.py
+++ b/mkdocs_toc_sidebar_plugin/plugin.py
@@ -25,16 +25,16 @@ class TocSidebar(BasePlugin):
         soup = BeautifulSoup(output_content, 'html.parser')
         nav_extra = soup.find("div", {"class": "sidebar"})
         if nav_extra:
-            soup_toc = soup.find("div", {"data-md-component" : "toc"})
-            
+            soup_toc = soup.find("div", {"data-md-type" : "toc"})
             if soup_toc:
-                scrollwrap = soup_toc.findNext("div", {"class" : "md-sidebar__scrollwrap"})
+                scrollwrap = soup_toc.find("div", {"class" : "md-sidebar__scrollwrap"})
                 if scrollwrap:
                     scrollwrap.insert(0, nav_extra)
+                else:
+                    print("WARNING (ToC Sidebar): Insertion point not found in %s" % page.file.src_path)
             else:
-                print("WARNING: Table of Contents sidebar not found")
+                print("WARNING (ToC Sidebar): Table of Contents in sidebar not found in %s" % page.file.src_path)
    
-        #souped_html = soup.prettify(soup.original_encoding)
         souped_html = soup.encode(soup.original_encoding) if soup.original_encoding else str(soup)
         return souped_html 
 

--- a/mkdocs_toc_sidebar_plugin/plugin.py
+++ b/mkdocs_toc_sidebar_plugin/plugin.py
@@ -35,6 +35,6 @@ class TocSidebar(BasePlugin):
                 print("WARNING: Table of Contents sidebar not found")
    
         #souped_html = soup.prettify(soup.original_encoding)
-        souped_html = soup.encode(soup.original_encoding) if soup.original_encoding else soup.str()
+        souped_html = soup.encode(soup.original_encoding) if soup.original_encoding else str(soup)
         return souped_html 
 

--- a/mkdocs_toc_sidebar_plugin/plugin.py
+++ b/mkdocs_toc_sidebar_plugin/plugin.py
@@ -35,6 +35,6 @@ class TocSidebar(BasePlugin):
                 print("WARNING: Table of Contents sidebar not found")
    
         #souped_html = soup.prettify(soup.original_encoding)
-        souped_html = soup.encode(soup.original_encoding)
+        souped_html = soup.encode(soup.original_encoding) if soup.original_encoding else soup.str()
         return souped_html 
 


### PR DESCRIPTION
Fixes midnightprioriem/mkdocs-toc-sidebar-plugin#4 (beautification removal to avoid altering the meaning of HTML).

Adds support for the latest (at the time of writing) Material theme v7.1.3 (lookup strategy adjusted: new attribute is used in the theme for ToC (`data-md-type = "toc"`).

P.S.: this branch is for the extension version w/o the fix for midnightprioriem/mkdocs-toc-sidebar-plugin#3 integrated. The master branch here has the fix integrated.