### PR TITLE
Update plugin.py

### DIFF
--- a/mkdocs_toc_sidebar_plugin/plugin.py
+++ b/mkdocs_toc_sidebar_plugin/plugin.py
@@ -3,7 +3,6 @@ import sys
 from timeit import default_timer as timer
 from datetime import datetime, timedelta
 
-from mkdocs import utils as mkdocs_utils
 from mkdocs.config import config_options, Config
 from mkdocs.plugins import BasePlugin
 
@@ -14,7 +13,7 @@ import codecs
 class TocSidebar(BasePlugin):
 
     config_scheme = (
-        ('param', config_options.Type(mkdocs_utils.string_types, default='')),
+        ('param', config_options.Type(str, default='')),
     )
 
     def __init__(self):


### PR DESCRIPTION
Fixed compatibility issue with mkdocs 1.1 which resulted in a runtime error: AttributeError: module 'mkdocs.utils' has no attribute 'string_types'